### PR TITLE
Fix error with extension when empty address second line

### DIFF
--- a/Command/CreatePaymentCommand.php
+++ b/Command/CreatePaymentCommand.php
@@ -69,8 +69,8 @@ class CreatePaymentCommand extends Command
                 "address"   => [
                     "country"   => "ES",
                     "city"      => "Madrid",
-                    "line1"     => "Fake Street 1",
-                    "line2"     => "",
+                    "line1"     => "Fake Street",
+                    "line2"     => "1",
                     "zip"       => "28001",
                     "state"     => "Madrid",
                 ]
@@ -83,8 +83,8 @@ class CreatePaymentCommand extends Command
                 "address"   => [
                     "country"   => "ES",
                     "city"      => "Madrid",
-                    "line1"     => "Fake Street 1",
-                    "line2"     => "",
+                    "line1"     => "Fake Street",
+                    "line2"     => "1",
                     "zip"       => "28001",
                     "state"     => "Madrid",
                 ]

--- a/Controller/Payment/Redirect.php
+++ b/Controller/Payment/Redirect.php
@@ -143,6 +143,10 @@ class Redirect implements ActionInterface
             unset($moneiAddress['company']);
         }
 
+        if (!$moneiAddress['line2']) {
+            unset($moneiAddress['line2']);
+        }
+
         return $moneiAddress;
     }
 }

--- a/Controller/Payment/Redirect.php
+++ b/Controller/Payment/Redirect.php
@@ -143,8 +143,8 @@ class Redirect implements ActionInterface
             unset($moneiAddress['company']);
         }
 
-        if (!$moneiAddress['line2']) {
-            unset($moneiAddress['line2']);
+        if (!$moneiAddress['address']['line2']) {
+            unset($moneiAddress['address']['line2']);
         }
 
         return $moneiAddress;


### PR DESCRIPTION
We discovered that there is an issue when order is placed with empty address (second line)

> [2022-05-26 15:34:10] moneiMoneiLogger.CRITICAL: Client error: `POST https://api.monei.com/v1/payments` resulted in a `400 Bad Request` response:
{"status":"BadRequestError","statusCode":400,"message":"\"line2\" is not allowed to be empty,\"line2\" is not allowed to (truncated...)