### PR TITLE
feat: add Monei frame-src CSP whitelist entry

### DIFF
--- a/etc/frontend/csp_whitelist.xml
+++ b/etc/frontend/csp_whitelist.xml
@@ -7,6 +7,11 @@
 -->
 <csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp/etc/csp_whitelist.xsd">
     <policies>
+        <policy id="frame-src">
+            <values>
+                <value id="monei" type="host">js.monei.com</value>
+            </values>
+        </policy>
         <policy id="script-src">
             <values>
                 <value id="monei" type="host">js.monei.com</value>


### PR DESCRIPTION
To enable the MONEI checkout functionality in Magento 2.4.7, the csp_whitelist.xml file includes a frame-src policy. This policy adds 'js.monei.com' to the list of allowed sources for iframe content. The relevant section in the XML file is:

```
<policy id="frame-src">
    <values>
        <value id="monei" type="host">js.monei.com</value>
    </values>
</policy>
```
This addition to the Content Security Policy (CSP) whitelist ensures that the MONEI JavaScript can be loaded within an iframe during the checkout process, allowing for seamless integration of the MONEI payment gateway.

Otherwise, the credit card cannot be entered, giving this error in the console.

<img width="2000" alt="image" src="https://github.com/user-attachments/assets/2b58522e-f68c-4496-9fd9-cd6876d23a4e">
