### PR TITLE
chore: Update README and workflow for release artifact naming

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: "zip"
-          filename: "monei-module-monei-payment-${{github.event.release.tag_name}}.zip"
+          filename: "monei-module-monei-payment.zip"
           exclusions: |
             *.git*
             *.github*
@@ -42,6 +42,6 @@ jobs:
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true
-          artifacts: "monei-module-monei-payment-${{github.event.release.tag_name}}.zip"
+          artifacts: "monei-module-monei-payment.zip"
           artifactContentType: "application/zip"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ bin/magento cache:clean
 Alternatively, you can use this one-line command to download and extract the latest release:
 
 ```bash
-curl -L https://github.com/MONEI/MONEI-AdobeCommerce-Magento2/archive/refs/heads/main.zip -o monei.zip && \
+curl -L https://github.com/MONEI/MONEI-AdobeCommerce-Magento2/releases/monei-module-monei-payment.zip -o monei.zip && \
 mkdir -p app/code/Monei/MoneiPayment && \
 unzip monei.zip && \
 cp -r MONEI-AdobeCommerce-Magento2-main/* app/code/Monei/MoneiPayment/ && \
@@ -124,7 +124,7 @@ rm -rf monei.zip MONEI-AdobeCommerce-Magento2-main
 
 #### Option 2: Via Main Branch
 
-1. Download the [latest version](https://github.com/MONEI/MONEI-AdobeCommerce-Magento2/archive/refs/heads/main.zip) from the main branch
+1. Download the [latest version](https://github.com/MONEI/MONEI-AdobeCommerce-Magento2/releases/monei-module-monei-payment.zip) from the main branch
 2. Create a directory called `app/code/Monei/MoneiPayment` inside your Magento 2 project
 3. Unzip the downloaded archive in this directory
 4. Install the MONEI PHP SDK:


### PR DESCRIPTION
- Changed the download link in README.md to point to the latest release zip file.
- Updated GitHub Actions workflow to simplify the artifact naming by removing the version tag from the filename.