### PR TITLE
fix: cast history comment to string for consistency in PaymentProcessor. Fixes #83

### DIFF
--- a/Model/PaymentProcessor.php
+++ b/Model/PaymentProcessor.php
@@ -486,7 +486,7 @@ class PaymentProcessor implements PaymentProcessorInterface
             // Find and update invoice and capture related entries
             foreach ($historyEntries as $history) {
                 if (!$history->getIsCustomerNotified() && $history->getComment()) {
-                    $comment = $history->getComment();
+                    $comment = (string) $history->getComment();
                     // Check for various capture-related texts
                     if (stripos($comment, 'Captured amount') !== false ||
                             stripos($comment, 'Invoice') !== false ||


### PR DESCRIPTION
fix #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of payment history comment processing to ensure consistent handling of capture-related notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->